### PR TITLE
Ajout de la startDate et endDate sur Anilist 

### DIFF
--- a/Anilist.js
+++ b/Anilist.js
@@ -37,11 +37,11 @@ module.exports = async function importAnilist(username, uid) {
                             month
                             day
                         }
-					    completedAt {
-						    year
-							month
-							day
-						}
+			completedAt {
+                            year
+                            month
+                            day
+                        }
                     }
                 }
             }

--- a/Anilist.js
+++ b/Anilist.js
@@ -76,7 +76,7 @@ module.exports = async function importAnilist(username, uid) {
                 let iso8601StartDate = null;
                 let iso8601EndDate = null;
                 if (item.startedAt && item.startedAt.year) {
-                    iso8601StartDate = `${item.startedAt.year}-00-00T00:00:00.000Z`
+                    iso8601StartDate = `${item.startedAt.year}-01-01T00:00:00.000Z`
                     if (item.startedAt.month && item.startedAt.day) {
                     iso8601StartDate =`${item.startedAt.year}-${item.startedAt.month.toString().padStart(2, '0')}-${item.startedAt.day.toString().padStart(2, '0')}T00:00:00.000Z`
                     }
@@ -84,7 +84,7 @@ module.exports = async function importAnilist(username, uid) {
 
                 if(item.completedAt && item.completedAt.year)
                 {
-                    iso8601EndDate = `${item.completedAt.year}-00-00T00:00:00.000Z`
+                    iso8601EndDate = `${item.completedAt.year}-01-01T00:00:00.000Z`
 
                     if (item.completedAt.month && item.completedAt.day){
                         iso8601EndDate =`${item.completedAt.year}-${item.completedAt.month.toString().padStart(2, '0')}-${item.completedAt.day.toString().padStart(2, '0')}T00:00:00.000Z`

--- a/Anilist.js
+++ b/Anilist.js
@@ -14,7 +14,7 @@ let status_formater = {
 module.exports = async function importAnilist(username, uid) {
 
     const query = `
-        query ($userName: String) {
+       query ($userName: String) {
             MediaListCollection(userName: $userName, type: ANIME) {
                 lists {
                     name
@@ -32,6 +32,16 @@ module.exports = async function importAnilist(username, uid) {
                         status
                         score
                         progress
+                        startedAt {
+                            year
+                            month
+                            day
+                        }
+					    completedAt {
+						    year
+							month
+							day
+						}
                     }
                 }
             }
@@ -61,12 +71,33 @@ module.exports = async function importAnilist(username, uid) {
     data.data.MediaListCollection.lists.forEach((e) => {
         if (['Watching', 'Completed', 'Paused', 'Dropped', 'Planning', 'Rewatching'].includes(e.name)) {
             e.entries.forEach((item) => {
+                //Modification de la date afin de correspondre a la data hyakanime
+
+                let iso8601StartDate = null;
+                let iso8601EndDate = null;
+                if (item.startedAt && item.startedAt.year) {
+                    iso8601StartDate = `${item.startedAt.year}-00-00T00:00:00.000Z`
+                    if (item.startedAt.month && item.startedAt.day) {
+                    iso8601StartDate =`${item.startedAt.year}-${item.startedAt.month.toString().padStart(2, '0')}-${item.startedAt.day.toString().padStart(2, '0')}T00:00:00.000Z`
+                    }
+                }
+
+                if(item.completedAt && item.completedAt.year)
+                {
+                    iso8601EndDate = `${item.completedAt.year}-00-00T00:00:00.000Z`
+
+                    if (item.completedAt.month && item.completedAt.day){
+                        iso8601EndDate =`${item.completedAt.year}-${item.completedAt.month.toString().padStart(2, '0')}-${item.completedAt.day.toString().padStart(2, '0')}T00:00:00.000Z`
+                    }
+                }
                 formated_anilist_progression.push({
                     id: item.media.id,
                     title: item.media.title.english ? item.media.title.english : item.media.title.romaji ? item.media.title.romaji : item.media.title.natif,
                     status: item.status,
                     progression: item.progress,
-                    score: item.score
+                    score: item.score,
+                    startDate : iso8601StartDate,
+                    endDate : iso8601EndDate
                 })
             })
         }
@@ -94,7 +125,9 @@ module.exports = async function importAnilist(username, uid) {
                 progression: e.progression,
                 status: status_formater[e.status],
                 score: e.score,
-                uid: uid
+                uid: uid,
+                startDate : e.startDate,
+                endDate : e.endDate
             })
             added_anime.push(e.title)
         }


### PR DESCRIPTION
Salut , un petit pull request qui permet d'ajouter la date de début et de fin de visionnage d'un anime d'anilist a hyakanime .

Dans le pr j'ai ajouter dans la querry les dates pour l'api anilist et j'ai fait un petit convertisseur pour convertir le type de date d'anilist a hyakanime. J'ai aussi fait en sorte que la data soit null si il n'y as pas de date d'inscrite ou bien que si il y ais seulement l'année qu'il soit bien converti correctement .

Le système de conversion est tout simple et ne devrais pas avoir d'erreur majeur a ma connaissance sachant que l'iso 8601.

 