### PR TITLE
Fix du score Anilist / Mal

### DIFF
--- a/Anilist.js
+++ b/Anilist.js
@@ -1,5 +1,5 @@
 const Hyak_Anime = require("../model/Hyak_Anime");
-// const Hyak_Anime = require('./data/Hyak_Anime.json')
+//const Hyak_Anime = require('./data/Hyak_Anime.json')
 
 // Hyakanime status formater
 let status_formater = {
@@ -124,7 +124,7 @@ module.exports = async function importAnilist(username, uid) {
                 animeID: id,
                 progression: e.progression,
                 status: status_formater[e.status],
-                score: e.score,
+                score: e.score === 0 ? null : e.score,
                 uid: uid,
                 startDate: e.startDate,
                 endDate: e.endDate,

--- a/MAL.js
+++ b/MAL.js
@@ -44,7 +44,7 @@ module.exports = async function importMAL(file, uid) {
                 animeID: id,
                 progression: e.progression,
                 status: status_formater[e.status],
-                score: e.score,
+                score: e.score === 0 ? null : e.score,
                 uid: uid,
                 startDate: e.startDate,
                 endDate: e.endDate,


### PR DESCRIPTION
Petit fix qui ajoute une condition du fait que si le score est de 0 sur anilist et mal (0 = non noté sur les deux sites) au lieu de mettre 0 on le remplace par un null